### PR TITLE
ci: build docker images

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,42 @@
+name: Integration
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    if: "!contains(github.event.head_commit.message, 'skip_ci')"
+
+    runs-on: ubuntu-latest
+
+    name: Build docker images
+    steps:
+      - name: Checkout plug
+        uses: actions/checkout@v2
+        with:
+          path: plug
+
+      - name: Checkout PowerSimData
+        uses: actions/checkout@v2
+        with:
+          repository: Breakthrough-Energy/PowerSimData
+          token: ${{ secrets.CI_TOKEN_CLONE_REPO }}
+          path: PowerSimData
+
+      - name: Checkout REISE.jl
+        uses: actions/checkout@v2
+        with:
+          repository: Breakthrough-Energy/REISE.jl
+          token: ${{ secrets.CI_TOKEN_CLONE_REPO }}
+          path: REISE.jl
+
+      - run: docker build . -t powersimdata:latest
+        working-directory: PowerSimData
+
+      - run: docker build . -t reisejl:latest
+        working-directory: REISE.jl

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,139 @@
+# The remainder of this file taken from github/gitignore (kinda)
+# https://github.com/github/gitignore/blob/master/Python.gitignore
+
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# Editors
+.vscode/
+.idea/
+
+# Mac/OSX
+.DS_Store
+
+# Windows
+Thumbs.db


### PR DESCRIPTION
### Purpose
Add ci job to build docker images which will be used in testing workflows

### What it does
Clone reise.jl and powersimdata and build the images on their current develop branches. For now it is triggered only by events in this repo, but at some point we can have it triggered on merges to those repos, which will close the feedback loop. 

I copied the .gitignore from powersimdata since we will probably have some python code here as well (and it has the .DS_Store entry in it)

### Time to review
3 mins - doesn't do much now, so if it passes the build after I create this PR it is good to go 