### PR TITLE
ci: remove obsolete token

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,14 +24,12 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: Breakthrough-Energy/PowerSimData
-          token: ${{ secrets.CI_TOKEN_CLONE_REPO }}
           path: PowerSimData
 
       # - name: Checkout REISE.jl
       #   uses: actions/checkout@v2
       #   with:
       #     repository: Breakthrough-Energy/REISE.jl
-      #     token: ${{ secrets.CI_TOKEN_CLONE_REPO }}
       #     path: REISE.jl
 
       - run: docker-compose build


### PR DESCRIPTION
### Purpose
Remove token used to clone previously private repositories

### Testing
The green check mark

### Time estimate
1 min