### PR TITLE
Use images from registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ PortabLe infrastrUcture for Grid modeling
 
 ### How to use
 To run the containerized framework, the only prerequisite is to have a gurobi
-license called `gurobi.lic` (as shown below) and the following directory structure
-obtained by cloning the three repositories into the same place (required for building the images).
+license called `gurobi.lic` in the `gurobi_license` folder as shown below. The required
+images will be downloaded automatically from our [container registry](https://github.com/orgs/Breakthrough-Energy/packages).
 
+Optionally, if you want to build any of the docker images locally (e.g. for development purposes),
+you should use the following directory structure so relative paths will work.
 
 ```bash
     .

--- a/scenario_framework/docker-compose.yml
+++ b/scenario_framework/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       context: ../../PowerSimData
     env_file:
       - client.env
-    image: powersimdata:latest
+    image: ghcr.io/breakthrough-energy/powersimdata:latest
     stdin_open: true # docker run -i
     tty: true        # docker run -t
     volumes:
@@ -33,7 +33,7 @@ services:
   #   hostname: reisejl
   #   build:
   #     context: ../../REISE.jl
-  #   image: reisejl:latest
+  #   image: ghcr.io/breakthrough-energy/reisejl:latest
   #   ports:
   #     - "80:5000"
   #   volumes:

--- a/standalone/docker-compose.yml
+++ b/standalone/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     hostname: powersimdata
     build:
       context: ../../PowerSimData
-    image: powersimdata:latest
+    image: ghcr.io/breakthrough-energy/powersimdata:latest
     entrypoint: bash
     stdin_open: true # docker run -i
     tty: true        # docker run -t
@@ -22,7 +22,7 @@ services:
     hostname: reisejl
     build:
       context: ../../REISE.jl
-    image: reisejl:latest
+    image: ghcr.io/breakthrough-energy/reisejl:latest
     ports:
       - "80:5000"
     volumes:


### PR DESCRIPTION
### Purpose
Use images from container registry to simplify installation. This removes the need to build containers locally, and the need to clone additional repositories, unless for local dev purposes.

### What it does
Use the pre built image if it exists, otherwise we still build locally but tag as `ghcr.io/breakthrough-energy/{image_name}:latest`.

### Testing
Ran `docker-compose build` followed by `docker image ls`. Not really necessary though since this is standard docker behavior.