### PR TITLE
chore: add override for local builds, update images and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,39 @@
 # plug
 PortabLe infrastrUcture for Grid modeling
 
+### Prerequisites
+To use *plug* you'll need to have docker installed - visit their [website](https://docs.docker.com/get-docker/)
+for details.
+
+If you want to run simulations using the Gurobi solver (recommended), you'll need a
+license file called `gurobi.lic` located at `plug/gurobi_license/gurobi.lic`
+
+*NOTE*: certain license types are not supported at the moment. 
+
 
 ### How to use
-To run the containerized framework, the only prerequisite is to have a gurobi
-license called `gurobi.lic` in the `gurobi_license` folder as shown below. The required
-images will be downloaded automatically from our [container registry](https://github.com/orgs/Breakthrough-Energy/packages).
-
-Optionally, if you want to build any of the docker images locally (e.g. for development purposes),
-you should use the following directory structure so relative paths will work.
-
-```bash
-    .
-    ├── plug
-        ├── gurobi_license/gurobi.lic
-    ├── PowerSimData
-    └── REISE.jl
-```
 
 We describe the workflow for running a standalone installation on a single
 computer. To get started, run `cd standalone` in your shell, followed by
-`docker-compose up`. In a separate shell, attach to the powersimdata client using
+`docker-compose up` (optionally pass `-d` to run in the background). 
+The docker images will be downloaded automatically 
+from our [container registry](https://github.com/orgs/Breakthrough-Energy/packages).
+
+The `client` container contains both [PowerSimData] and [PostREISE] packages, for
+scenario management and analysis, respectively. The default compose file starts the
+client running `bash`, which serves as an entrypoint to either an `ipython` shell:
 
 ```
-docker-compose exec powersimdata ipython
+docker-compose exec client ipython
+```
+ or a jupyter notebook:
+
+```
+docker-compose exec client jupyter lab --port=10000 --no-browser --ip=0.0.0.0 --allow-root
 ```
 
-See the PowerSimData [readme](https://github.com/Breakthrough-Energy/PowerSimData) for details 
-about how to run a simulation, or try the commands in `demo.py` for a simple example.
+See the PowerSimData [tutorial] for details 
+about how to run a simulation, or try the commands in `demo_*.py` for a simple example.
 
 The usage within the containerized setup is almost identical to what is
 presented in the PowerSimData repo, but there are some small differences. 
@@ -60,13 +66,31 @@ Currently, the simplest way to access simulation output is by copying the
 results from the container. To copy the full volume as-is, use the following:
 
 ```
-docker cp powersimdata:/mnt/bes/pcm DEST_FOLDER
+docker cp client:/mnt/bes/pcm DEST_FOLDER
 ```
 
 Optionally, to snapshot the results to a tar archive, run
 
 ```
-docker cp powersimdata:/mnt/bes/pcm - > FILENAME.tar
+docker cp client:/mnt/bes/pcm - > FILENAME.tar
+```
+
+### Local development
+If you want to build any of the docker images locally you should use the following 
+directory structure so relative paths will work.
+
+```bash
+    .
+    ├── plug
+    ├── PowerSimData
+    ├── PostREISE
+    └── REISE.jl
+```
+
+Then, to build the images when starting, use the override feature described [here][override],
+for example
+```
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml up --build
 ```
 
 ### Client/server architecture
@@ -88,3 +112,8 @@ docker exec scenario_client bash -c 'pytest -m "not db"'
 
 In addition to the test suite from powersimdata, this will run the tests
 provided here, which demonstrate typical user workflows. 
+
+[PowerSimData]: https://github.com/Breakthrough-Energy/PowerSimData
+[PostREISE]: https://github.com/Breakthrough-Energy/PostREISE
+[tutorial]: https://breakthrough-energy.github.io/docs/powersimdata/index.html
+[override]: https://docs.docker.com/compose/extends/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # plug
 PortabLe infrastrUcture for Grid modeling
 
-### Prerequisites
+## Prerequisites
 To use *plug* you'll need to have docker installed - visit their [website](https://docs.docker.com/get-docker/)
 for details.
 
@@ -11,7 +11,7 @@ license file called `gurobi.lic` located at `plug/gurobi_license/gurobi.lic`
 *NOTE*: certain license types are not supported at the moment. 
 
 
-### How to use
+## How to use
 
 We describe the workflow for running a standalone installation on a single
 computer. To get started, run `cd standalone` in your shell, followed by
@@ -61,7 +61,7 @@ doing so will simply print a warning). The data can be accessed from the
 `Analyze` state within the container, but if you have a use case that is not
 yet supported, the data can be detached from docker, which we describe below.
 
-### Extracting data
+## Extracting data
 Currently, the simplest way to access simulation output is by copying the
 results from the container. To copy the full volume as-is, use the following:
 
@@ -75,7 +75,7 @@ Optionally, to snapshot the results to a tar archive, run
 docker cp client:/mnt/bes/pcm - > FILENAME.tar
 ```
 
-### Local development
+## Local development
 If you want to build any of the docker images locally you should use the following 
 directory structure so relative paths will work.
 
@@ -93,7 +93,7 @@ for example
 docker-compose -f docker-compose.yml -f docker-compose.dev.yml up --build
 ```
 
-### Client/server architecture
+## Client/server architecture
 
 The contents of the `scenario_framework` folder are provided to mirror the client server
 architecture used internally and enable reproducible testing in that
@@ -110,7 +110,7 @@ docker-compose up -d
 docker exec scenario_client bash -c 'pytest -m "not db"'
 ```
 
-In addition to the test suite from powersimdata, this will run the tests
+In addition to the test suite from PowerSimData, this will run the tests
 provided here, which demonstrate typical user workflows. 
 
 [PowerSimData]: https://github.com/Breakthrough-Energy/PowerSimData

--- a/standalone/docker-compose.dev.yml
+++ b/standalone/docker-compose.dev.yml
@@ -1,0 +1,15 @@
+version: '3.7'
+
+services:
+  powersimdata: # included only for building postreise base image
+    build:
+      context: ../../PowerSimData
+    image: ghcr.io/breakthrough-energy/powersimdata:latest
+  client:
+    build:
+      context: ../../PostREISE
+    depends_on:
+      - powersimdata
+  reisejl:
+    build:
+      context: ../../REISE.jl

--- a/standalone/docker-compose.yml
+++ b/standalone/docker-compose.yml
@@ -1,27 +1,26 @@
 version: '3.7'
 
 services:
-  powersimdata:
-    container_name: powersimdata
-    hostname: powersimdata
-    build:
-      context: ../../PowerSimData
-    image: ghcr.io/breakthrough-energy/powersimdata:latest
-    entrypoint: bash
+  client:
+    container_name: client
+    hostname: client
+    image: ghcr.io/breakthrough-energy/postreise:latest
     stdin_open: true # docker run -i
     tty: true        # docker run -t
+    working_dir: /plug
+    entrypoint: bash
     volumes:
       - scenario_data:/mnt/bes/pcm
       - ../rootdir/raw:/mnt/bes/pcm/raw
-      - ./:/PowerSimData/plug
+      - ./:/plug
+    ports:
+      - "10000:10000"
     environment:
       - BE_SERVER_ADDRESS=reisejl
       - DEPLOYMENT_MODE=1
   reisejl:
     container_name: reisejl
     hostname: reisejl
-    build:
-      context: ../../REISE.jl
     image: ghcr.io/breakthrough-energy/reisejl:latest
     ports:
       - "80:5000"


### PR DESCRIPTION
### Purpose
Integrate some of the updates used for the training, and add override file for local builds. 

### Details
Switch the UI to postreise image as we did for the `jon/training` branch, and update readme accordingly. This also fixes a potential issue where if a user doesn't have the PostREISE repo checked out, running `docker-compose up` will fail due to the path from build context in the yml file not existing. To fix this we separate that into the `docker-compose.dev.yml` file which can extend the default `docker-compose.yml` file but only if desired. Since most users would probably use the images from the registry, this keeps the most common use case simple.

### Testing
Checked the behavior of `docker-compose up` and the override example added to the readme.

### Time to review
10 mins