### PR TITLE
chore: remove obsolete yaml

### DIFF
--- a/scenario_framework/docker-compose.yml
+++ b/scenario_framework/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   powersimdata:
     container_name: scenario_client
@@ -34,8 +32,6 @@ services:
   #   build:
   #     context: ../../REISE.jl
   #   image: ghcr.io/breakthrough-energy/reisejl:latest
-  #   ports:
-  #     - "80:5000"
   #   volumes:
   #     - scenario_data:/mnt/bes/pcm
       # - ../gurobi_license:/usr/share/gurobi_license

--- a/scenario_framework/server.env
+++ b/scenario_framework/server.env
@@ -1,5 +1,3 @@
 # value is arbitrary, but must match client
 USER_NAME=octocat
 PUBLIC_KEY_FILE=/pub_key/id_rsa.pub # ssh public key in container
-SUDO_ACCESS=false
-PASSWORD_ACCESS=false

--- a/standalone/docker-compose.dev.yml
+++ b/standalone/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   powersimdata: # included only for building postreise base image
     build:

--- a/standalone/docker-compose.yml
+++ b/standalone/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   client:
     container_name: client
@@ -22,8 +20,6 @@ services:
     container_name: reisejl
     hostname: reisejl
     image: ghcr.io/breakthrough-energy/reisejl:latest
-    ports:
-      - "80:5000"
     volumes:
       - scenario_data:/mnt/bes/pcm
       - ../rootdir/raw:/mnt/bes/pcm/raw


### PR DESCRIPTION
### Purpose
Mainly to remove the port mapping which is not necessary since the client container can communicate using the docker network, thus we don't need to bind to a host port. This should prevent errors some users encounter trying to start the containers if something is already using port 80.

### What the code is doing
* Remove unused port mapping
* Remove unnecessary version specifier
* Remove default values from server.env file

### Testing
Launched a simulation, which verifies that communication between containers still works.

### Time estimate
1 min
