### PR TITLE
Move docker build to plug repo

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
-          push: false
+          push: true
           context: build
           tags: ghcr.io/breakthrough-energy/postreise:latest

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,25 @@
+name: Publish docker image
+
+on: 
+  workflow_dispatch:
+  push:
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to GitHub Packages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          push: false
+          context: build
+          tags: ghcr.io/breakthrough-energy/postreise:latest

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,7 +2,6 @@ name: Publish docker image
 
 on: 
   workflow_dispatch:
-  push:
 
 jobs:
   push_to_registry:

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ __pycache__/
 
 # Distribution / packaging
 .Python
-build/
 develop-eggs/
 dist/
 downloads/

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.8.3
+
+RUN apt-get update
+RUN ln -s /mnt/bes/pcm $HOME/ScenarioData
+
+RUN pip install -U pip pipenv ipython jupyterlab ipywidgets
+
+RUN git clone --depth 1 https://github.com/Breakthrough-Energy/PowerSimData
+RUN git clone --depth 1 https://github.com/Breakthrough-Energy/PostREISE
+
+WORKDIR /PowerSimData
+RUN mkdir -p /mnt/bes/pcm
+RUN cp -r powersimdata/utility/templates /mnt/bes/pcm/
+
+WORKDIR /PostREISE
+RUN pipenv sync --dev --system;
+RUN pip install .
+RUN pip install ../PowerSimData
+
+WORKDIR /app
+RUN rm -rf /PowerSimData
+RUN rm -rf /PostREISE
+
+CMD ["jupyter", "lab", "--port=10000", "--no-browser", "--ip=0.0.0.0", "--allow-root"]

--- a/standalone/docker-compose.dev.yml
+++ b/standalone/docker-compose.dev.yml
@@ -1,13 +1,7 @@
 services:
-  powersimdata: # included only for building postreise base image
-    build:
-      context: ../../PowerSimData
-    image: ghcr.io/breakthrough-energy/powersimdata:latest
   client:
     build:
-      context: ../../PostREISE
-    depends_on:
-      - powersimdata
+      context: ../build
   reisejl:
     build:
       context: ../../REISE.jl


### PR DESCRIPTION
### Purpose
Consolidate the builds currently in powersimdata and postreise, which prevents having an out of date postreise image or the need to synchronize builds across repos. Currently, only the `latest` tag is built, but in the future I'm thinking the simplest option would be to have a `stable` tag which builds the latest versioned postreise image, and make that the default in the compose files included here.

### What the code is doing
Add the Dockerfile and update things as necessary. In particular, the `.dev.yml` file provided for users who want to build locally, which now works without cloning any other repos. 

### Testing
Ran the build with docker compose using the override file. Quick test using the resulting image to make sure we can still import from powersimdata and postreise. 

### Time estimate
15 min
