### PR TITLE
ci: simplify integration workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: Integration
 
-on: [workflow_dispatch]
+on:
+  workflow_dispatch:
 
 jobs:
   build:
@@ -10,30 +11,15 @@ jobs:
 
     name: End to end tests
     steps:
-      - name: Checkout plug
-        uses: actions/checkout@v2
-        with:
-          path: plug
+      - uses: actions/checkout@v2
 
-      - name: Checkout PowerSimData
-        uses: actions/checkout@v2
-        with:
-          repository: Breakthrough-Energy/PowerSimData
-          path: PowerSimData
-
-      # - name: Checkout REISE.jl
-      #   uses: actions/checkout@v2
-      #   with:
-      #     repository: Breakthrough-Energy/REISE.jl
-      #     path: REISE.jl
-
-      - run: docker-compose build
-        working-directory: plug/scenario_framework
+      - run: docker-compose build scenario_server
+        working-directory: scenario_framework
 
       - name: Start containers
         run: |
           docker-compose up -d
           sleep 10
-        working-directory: plug/scenario_framework
+        working-directory: scenario_framework
 
       - run: docker exec scenario_client bash -c 'pytest -m "not db"'

--- a/scenario_framework/docker-compose.yml
+++ b/scenario_framework/docker-compose.yml
@@ -1,12 +1,12 @@
 services:
-  powersimdata:
+  scenario_client:
     container_name: scenario_client
     hostname: scenario_client
     build:
-      context: ../../PowerSimData
+      context: ../build
     env_file:
       - client.env
-    image: ghcr.io/breakthrough-energy/powersimdata:latest
+    image: ghcr.io/breakthrough-energy/postreise:latest
     stdin_open: true # docker run -i
     tty: true        # docker run -t
     volumes:


### PR DESCRIPTION
### Purpose
Keep the workflow up to date with other changes.

### What the code is doing
* only build the `scenario_server` container since we can reuse the postreise image from ghcr
* update the build context for `scenario_client` which is now hosted in the plug/build directory

### Testing
I added the `push:` trigger to run the workflow. It actually fails due to some pandas error (see [logs](https://github.com/Breakthrough-Energy/plug/runs/3427641692#step:5:14)), but pretty sure that's unrelated. 

### Time estimate
5 min
