### PR TITLE
ci: support for stable build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,6 +2,11 @@ name: Publish docker image
 
 on: 
   workflow_dispatch:
+    inputs:
+      imageTag:
+        description: 'Tag to push'
+        required: false
+        default: 'latest'
 
 jobs:
   push_to_registry:
@@ -21,4 +26,5 @@ jobs:
         with:
           push: true
           context: build
-          tags: ghcr.io/breakthrough-energy/postreise:latest
+          build-args: version=${{ github.event.inputs.imageTag }}
+          tags: ghcr.io/breakthrough-energy/postreise:${{ github.event.inputs.imageTag }}

--- a/README.md
+++ b/README.md
@@ -82,8 +82,6 @@ directory structure so relative paths will work.
 ```bash
     .
     ├── plug
-    ├── PowerSimData
-    ├── PostREISE
     └── REISE.jl
 ```
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.8.3
+ARG version=latest
 
 RUN apt-get update
 RUN ln -s /mnt/bes/pcm $HOME/ScenarioData
@@ -12,10 +13,8 @@ WORKDIR /PowerSimData
 RUN mkdir -p /mnt/bes/pcm
 RUN cp -r powersimdata/utility/templates /mnt/bes/pcm/
 
-WORKDIR /PostREISE
-RUN pipenv sync --dev --system;
-RUN pip install .
-RUN pip install ../PowerSimData
+COPY install.sh .
+RUN ./install.sh $version
 
 WORKDIR /app
 RUN rm -rf /PowerSimData

--- a/build/install.sh
+++ b/build/install.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+echo "Installing packages for image: $1"
+
+if [[ $1 = "latest" ]]
+then
+    cd /PostREISE
+    pip install .
+    cd /PowerSimData
+    pip install .
+elif [[ $1 = "stable" ]]
+then
+    pip install postreise
+else
+    echo "Unknown installation mode"
+fi

--- a/standalone/docker-compose.dev.yml
+++ b/standalone/docker-compose.dev.yml
@@ -1,5 +1,6 @@
 services:
   client:
+    image: ghcr.io/breakthrough-energy/postreise:latest
     build:
       context: ../build
   reisejl:

--- a/standalone/docker-compose.yml
+++ b/standalone/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   client:
     container_name: client
     hostname: client
-    image: ghcr.io/breakthrough-energy/postreise:latest
+    image: ghcr.io/breakthrough-energy/postreise:stable
     stdin_open: true # docker run -i
     tty: true        # docker run -t
     working_dir: /plug


### PR DESCRIPTION
### Purpose
Add version argument to docker build which allows reusing the dockerfile to produce both latest and stable images. 

### What the code is doing
The `latest` branch is unchanged, but now we could also pass `stable` as an input to the workflow, which will get passed as a build-arg to docker, causing it to install the package from PyPI instead. The default image in the compose file is changed to be `stable`, but a user can override this using the `.dev.yml` file.

### Testing
Tested the bash script and stable build from the command line, and tested the workflow input functionality in my test-ci repo. Example:
```
cd build
docker build . -t client:stable --build-arg version=stable
```

### Time estimate
5 min
