### PR TITLE
fix: copy templates to the right location

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -11,7 +11,7 @@ RUN git clone --depth 1 https://github.com/Breakthrough-Energy/PostREISE
 
 WORKDIR /PowerSimData
 RUN mkdir -p /mnt/bes/pcm
-RUN cp -r powersimdata/utility/templates /mnt/bes/pcm/
+RUN cp powersimdata/utility/templates/*.csv /mnt/bes/pcm/
 
 COPY install.sh .
 RUN ./install.sh $version


### PR DESCRIPTION
### Purpose
Copy blank scenario/execute list to the right place when we build the docker image. Currently, the files will be in a `templates/` folder which causes a `FileNotFoundError` when looking for the scenario list. 

### What the code is doing
Update the dockerfile. I guess when I did this initially I forgot to delete the existing docker volume. 

### Testing
Tested the command locally in the current `:latest` container.

### Time estimate
1 min
